### PR TITLE
update version for rlenv 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lle"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ authors = ["Yannick Molinghen <yannick.molinghen@ulb.be>"]
 description = "Laser Learning Environment (LLE) for Multi-Agent Reinforcement Learning"
 name = "lle"
 readme = "README.md"
-version = "0.1.7"
+version = "0.1.8"
 
 [tool.poetry.dependencies]
 numpy = "^1.25.0"


### PR DESCRIPTION
due of the update on rlenv but the version of LLE being the same when we do a poetry update the Old version of LLE is not working with the new version of rlenv  ( i tryed to copy what you have done before for updating version I also know is not my job to do this kind of job but i want to learn how a "advance" project work by trying to contribute with the knowledge that i acquired here ) and if i do something that is unnecessary or wrong can you explain me where i should correct ?   